### PR TITLE
Create a lambda to query public portfolios

### DIFF
--- a/public_graphql_lambda/README.md
+++ b/public_graphql_lambda/README.md
@@ -1,0 +1,31 @@
+# public_graphql_lambda
+This lambda will be called by an API Gateway.
+It will look up the AppSync API Keys from SSM, attach that key to the header, and make a call to AppSync.  The results of that query will be returned to the calling process.
+
+# Requirements
+Required parameters include:
+    event['resource'] = '/query/{id}'
+    event['pathParameters'] = {"id": "listPublicFeaturedPortfolioCollections"}
+    event['body'] = '''query MyQuery {
+        listPublicFeaturedPortfolioCollections {
+            items {
+                portfolioUserId
+                portfolioCollectionId
+                description
+                featuredCollection
+                highlightedCollection
+                layout
+                imageUri
+                privacy
+            }
+        }
+    }'''
+
+
+If the query in the body does not start with "query", then we concatenate "query MyQuery {" + {the query that is passed} + "}"
+
+The expected API signature must be one of these:
+* /query/listPublicPortfolioCollections
+* /query/listHighlightedPortfolioCollections
+* /query/listPublicFeaturedPortfolioCollections
+* /query/getExposedPortfolioCollection

--- a/public_graphql_lambda/__init__.py
+++ b/public_graphql_lambda/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+where_i_am = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(where_i_am)
+sys.path.append(where_i_am + "/dependencies/")

--- a/public_graphql_lambda/_set_path.py
+++ b/public_graphql_lambda/_set_path.py
@@ -1,0 +1,4 @@
+import os
+import sys
+where_i_am = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(where_i_am + "/dependencies")

--- a/public_graphql_lambda/handler.py
+++ b/public_graphql_lambda/handler.py
@@ -1,0 +1,160 @@
+import _set_path  # noqa
+import boto3
+import botocore
+import os
+import sentry_sdk
+from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
+import json
+from urllib import request, error
+
+
+if 'SENTRY_DSN' in os.environ:
+    sentry_sdk.init(
+        dsn=os.environ['SENTRY_DSN'],
+        integrations=[AwsLambdaIntegration()]
+    )
+
+
+def run(event, context):
+
+    status_code = 200  # default to Success
+    results_json = {}
+
+    graphql_url = _get_ssm_parameter(_get_graphql_api_url_key_path())
+    graphql_key = _get_ssm_parameter(_get_graphql_api_key_key_path())
+
+    resource = _get_resource(event)
+    if resource not in ['query']:
+        status_code = 405  # Method not found
+    id = _get_id(event)
+    if id not in ['listPublicPortfolioCollections', 'listHighlightedPortfolioCollections', 'listPublicFeaturedPortfolioCollections', 'getExposedPortfolioCollection']:
+        status_code = 405  # Method not found
+    query = event.get('body')
+    if graphql_url and graphql_key and resource and id and query:
+        try:
+            results = query_appsync(graphql_url, graphql_key, query)
+            results_json = results.get('data', {}).get(id)
+        except Exception as err:
+            print("error on {}".format(id))
+            print("Error: {}".format(err))
+            results_json = {}
+    else:
+        print("unable to call AppSync, we're missing key information.")
+        print("graphql_url =", graphql_url)
+        print("resource =", resource)
+        print("id =", id)
+        if not graphql_key:
+            print("missing graphql_key")
+
+    # if results_json:
+    #     with open('results_json.json', 'w') as output_file:
+    #         json.dump(results_json, output_file, indent=2)
+
+    return build_http_results(results_json, status_code)
+
+
+def _get_graphql_api_url_key_path() -> str:
+    return os.environ.get('GRAPHQL_API_URL_KEY_PATH')
+
+
+def _get_graphql_api_key_key_path() -> str:
+    return os.environ.get('GRAPHQL_API_KEY_KEY_PATH')
+
+
+def _get_resource(event: dict) -> str:
+    return event.get('resource', "").replace("{id}", "").replace("/", "")
+
+
+def _get_id(event: dict) -> str:
+    # print("pathParamters = ", event.get("pathParameters"))
+    return event.get("pathParameters", {}).get("id", "")
+
+
+def build_http_results(results_json: dict, status_code: int) -> dict:
+    if status_code == 200 and not results_json:
+        status_code = 400  # Bad Request
+    if status_code != 200:
+        results_json = {}  # Blank out results if all is not well.
+    return {
+        "headers": {'Access-Control-Allow-Origin': '*'},
+        "statusCode": status_code,
+        "body": json.dumps(results_json)
+    }
+
+
+def _get_ssm_parameter(name: str) -> str:
+    if not name:
+        return None
+    try:
+        response = boto3.client('ssm').get_parameter(Name=name, WithDecryption=True)
+        value = response.get('Parameter').get('Value')
+        return value
+    except botocore.exceptions.ClientError:
+        print("can't read ssm parameter: ", name)
+        return None
+
+
+def query_appsync(graphql_api_url: str, graphql_api_key: str, query: str):
+    if not query.startswith('query'):
+        query = 'query MyQuery {' + str(query) + '}'
+    data = json.dumps({"query": query})
+
+    r = request.Request(
+        headers={"x-api-key": graphql_api_key},
+        url=graphql_api_url,
+        method="POST",
+        data=data.encode("utf8")
+    )
+    try:
+        response = request.urlopen(r).read()
+        return json.loads(response.decode("utf8"))
+    except error.URLError as ue:
+        print("error:", ue)
+        return {}
+
+
+# python -c 'from handler import *; test()'
+
+# export GRAPHQL_API_URL_KEY_PATH=/all/stacks/steve-maintain-metadata/graphql-api-url
+# export GRAPHQL_API_KEY_KEY_PATH=/all/stacks/steve-maintain-metadata/graphql-api-key
+# aws-vault exec testlibnd-superAdmin
+
+
+# export GRAPHQL_API_URL_KEY_PATH=/all/stacks/marbleb-prod-maintain-metadata/graphql-api-url
+# export GRAPHQL_API_KEY_KEY_PATH=/all/stacks/marbleb-prod-maintain-metadata/graphql-api-key
+# python -c 'from handler import *; test()'
+
+
+def test():
+    event = {}
+    event['resource'] = '/query/{id}'
+    event['pathParameters'] = {"id": "listPublicFeaturedPortfolioCollections"}
+    event['body'] = '''query MyQuery {
+        listPublicFeaturedPortfolioCollections {
+            items {
+                portfolioUserId
+                portfolioCollectionId
+                description
+                featuredCollection
+                highlightedCollection
+                layout
+                imageUri
+                privacy
+            }
+        }
+    }'''
+
+    event['body'] = '''listPublicFeaturedPortfolioCollections {
+            items {
+                portfolioUserId
+                portfolioCollectionId
+                description
+                featuredCollection
+                highlightedCollection
+                layout
+                imageUri
+                privacy
+            }
+        }'''
+    results = run(event, {})
+    print("results =", results)

--- a/public_graphql_lambda/requirements.txt
+++ b/public_graphql_lambda/requirements.txt
@@ -1,0 +1,2 @@
+
+sentry_sdk

--- a/public_graphql_lambda/results_json.json
+++ b/public_graphql_lambda/results_json.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+    {
+      "portfolioUserId": "dwolfe2",
+      "portfolioCollectionId": "B",
+      "description": "port b public",
+      "featuredCollection": true,
+      "highlightedCollection": true,
+      "layout": "default",
+      "imageUri": null,
+      "privacy": "public"
+    }
+  ]
+}

--- a/scripts/codebuild/install.sh
+++ b/scripts/codebuild/install.sh
@@ -9,3 +9,8 @@ mkdir dependencies
 pip install -r requirements.txt -t ./dependencies
 popd
 
+pushd public_graphql_lambda
+rm -rf ./dependencies
+mkdir dependencies
+pip install -r requirements.txt -t ./dependencies
+popd


### PR DESCRIPTION
* create a lambda to accept  graphQL query, lookup AppSync API keys, and apply them to the header, and pass query to AppSync, returning results to calling client.
* the only permitted resolvers include: ['listPublicPortfolioCollections', 'listHighlightedPortfolioCollections', 'listPublicFeaturedPortfolioCollections', 'getExposedPortfolioCollection']