### PR TITLE
Marble 1608 include media in manifest generation

### DIFF
--- a/manifest_lambda/get_iiif_manifest_pdf_rendering_section.py
+++ b/manifest_lambda/get_iiif_manifest_pdf_rendering_section.py
@@ -1,0 +1,32 @@
+import os
+
+
+def return_pdf_rendering(standard_json: dict) -> dict:
+    first_pdf_json = _return_first_pdf_media_item(standard_json)
+    if not first_pdf_json:
+        return {}
+    else:
+        return _pdf_rendering(first_pdf_json)
+
+
+def _return_first_pdf_media_item(standard_json: dict) -> dict:
+    for media_item in standard_json.get('media', {}).get('items', []):
+        if '.pdf' in media_item.get('mediaResourceId') or media_item.get('mimeType') == 'application/pdf':
+            return media_item
+    return {}
+
+
+def _pdf_rendering(pdf_json: dict) -> dict:
+    if not pdf_json.get('mediaResourceId', '') or not pdf_json.get('mediaServer', ''):
+        return {}
+    mediaResourceId = pdf_json.get('mediaResourceId', '')
+    if not mediaResourceId.startswith('media'):
+        mediaResourceId = 'media%2F' + mediaResourceId
+    return [
+        {
+            "id": os.path.join(pdf_json.get('mediaServer', ''), mediaResourceId),
+            "type": "Text",
+            "label": {"en": ["PDF version"]},
+            "format": pdf_json.get('mediaType', 'application/pdf')
+        }
+    ]

--- a/manifest_lambda/get_iiif_manifest_provider.py
+++ b/manifest_lambda/get_iiif_manifest_provider.py
@@ -1,0 +1,115 @@
+def return_provider(repository: str, level: str) -> dict:
+    if not repository or not level or level == 'file':
+        return
+    repository = repository.lower()
+    if (repository == 'museum'):
+        return _snite_proivider()
+    elif (repository == 'unda'):
+        return _archives_proivider()
+    elif (repository == 'rare' or repository == 'curate'):
+        return _rbsc_proivider()
+    elif (repository == 'hesb'):
+        return _hesb_proivider()
+    else:
+        raise Exception("bad provider " + repository.lower())
+        return
+
+
+def _snite_proivider() -> dict:
+    return {
+        "id": "https://sniteartmuseum.nd.edu/about-us/contact-us/",
+        "type": "Agent",
+        "label": {"en": ["Snite Museum of Art"]},
+        "homepage": [
+            {
+                "id": "https://sniteartmuseum.nd.edu",
+                "type": "Text",
+                "label": {"en": ["Snite Museum of Art"]},
+                "format": "text/html"
+            }
+        ],
+        "logo": [
+            {
+                "id": "https://sniteartmuseum.nd.edu/stylesheets/images/snite_logo@2x.png",
+                "type": "Image",
+                "format": "image/png",
+                "height": 100,
+                "width": 120
+            }
+        ]
+    }
+
+
+def _rbsc_proivider() -> dict:
+    return {
+        "id": "https://rarebooks.library.nd.edu/using",
+        "type": "Agent",
+        "label": {"en": ["Rare Books and Special Collections, Hesburgh Libraries, University of Notre Dame"]},
+        "homepage": [
+            {
+                "id": "https://rarebooks.library.nd.edu/",
+                "type": "Text",
+                "label": {"en": ["Rare Books and Special Collections, Hesburgh Libraries, University of Notre Dame"]},
+                "format": "text/html"
+            }
+        ],
+        "logo": [
+            {
+                "id": "https://rarebooks.library.nd.edu/images/hesburgh_mark.png",
+                "type": "Image",
+                "format": "image/png",
+                "height": 100,
+                "width": 120
+            }
+        ]
+    }
+
+
+def _archives_proivider() -> dict:
+    return {
+        "id": "http://archives.nd.edu/about/",
+        "type": "Agent",
+        "label": {"en": ["University of Notre Dame Archives, Hesburgh Libraries, University of Notre Dame"]},
+        "homepage": [
+            {
+                "id": "http://archives.nd.edu/",
+                "type": "Text",
+                "label": {"en": ["University of Notre Dame Archives"]},
+                "format": "text/html"
+            }
+        ],
+        "logo": [
+            {
+                "id": "https://rarebooks.library.nd.edu/images/hesburgh_mark.png",
+                "type": "Image",
+                "format": "image/png",
+                "height": 100,
+                "width": 120
+            }
+        ]
+    }
+
+
+def _hesb_proivider() -> dict:
+    return {
+        "id": "https://library.nd.edu",
+        "type": "Agent",
+        "label": {"en": ["General Collection, Hesburgh Libraries"]},
+        "homepage": [
+            {
+                "id": "https://library.nd.edu/",
+                "type": "Text",
+                "label": {"en": ["General Collection, Hesburgh Libraries"]},
+                "format": "text/html"
+            }
+        ],
+        "logo": [
+            {
+                "id": "https://library.nd.edu/static/media/library.logo.43a05388.png",
+                "type": "Image",
+                "format": "image/png",
+                "height": 100,
+                "width": 120
+            }
+        ]
+    }

--- a/manifest_lambda/graphql.py
+++ b/manifest_lambda/graphql.py
@@ -81,7 +81,24 @@ def build_manifest_query(id):
                     mimeType
                 }
             }
+            images {
+                items {
+                    id
+                    mediaResourceId
+                    mediaServer
+                    mimeType
+                }
             }
+            media {
+                items {
+                    id
+                    mediaResourceId
+                    mediaServer
+                    mimeType
+                }
+            }
+
+        }
     }
     '''
     return query

--- a/manifest_lambda/graphql.py
+++ b/manifest_lambda/graphql.py
@@ -36,11 +36,6 @@ def build_manifest_query(id):
             }
             dedication
             defaultFilePath
-            defaultFile {
-                id
-                mediaResourceId
-                mediaServer
-            }
             description
             dimensions
             format
@@ -73,14 +68,6 @@ def build_manifest_query(id):
                     description
                 }
             }
-            files {
-                items {
-                    id
-                    mediaResourceId
-                    mediaServer
-                    mimeType
-                }
-            }
             images {
                 items {
                     id
@@ -104,9 +91,9 @@ def build_manifest_query(id):
     return query
 
 
-def build_file_query(id):
+def build_image_query(id):
     query = '''query MyQuery {
-        getFile(id: "''' + id + '''"){
+        getImage(id: "''' + id.replace('%2F', '/') + '''"){
             id
             mediaResourceId
             mediaServer

--- a/manifest_lambda/handler.py
+++ b/manifest_lambda/handler.py
@@ -46,8 +46,8 @@ def run(event, context):
         print("resource =", resource)
         print("id =", id)
 
-    # with open('manifest.json', 'w') as output_file:
-    #     json.dump(manifest_json, output_file, indent=2)
+    with open('manifest.json', 'w') as output_file:
+        json.dump(manifest_json, output_file, indent=2)
 
     return build_http_results(manifest_json)
 
@@ -115,7 +115,7 @@ def _get_ssm_parameter(name: str) -> str:
 # export GRAPHQL_API_URL_KEY_PATH=/all/stacks/marbleb-prod-maintain-metadata/graphql-api-url
 # export GRAPHQL_API_KEY_KEY_PATH=/all/stacks/marbleb-prod-maintain-metadata/graphql-api-key
 # export IIIF_API_BASE_URL=presentation-iiif.library.nd.edu
-# aws-vault exec libnd-power-user-2
+# aws-vault exec libnd-power-user
 # python -c 'from handler import *; test()'
 
 def test():
@@ -127,10 +127,12 @@ def test():
     # event['id'] = 'MSNEa8006_EAD'
     # event['id'] = '1934.007.001'
     # event['id'] = 'aspace_8177830828c061f66a16bb593fa13af1'
+    # event['pathParameters']['id'] = 'pv63fx74g23'
+    event['pathParameters']['id'] = 'aspace_8177830828c061f66a16bb593fa13af1'
 
-    event['resource'] = '/canvas/{id}'
-    event['resource'] = '/annotation_page/{id}'
-    event['resource'] = '/annotation/{id}'
-    event['pathParameters'] = {"id": "1934.007.001%2F1934_007_001-v0002.tif"}
+    # event['resource'] = '/canvas/{id}'
+    # event['resource'] = '/annotation_page/{id}'
+    # event['resource'] = '/annotation/{id}'
+    # event['pathParameters'] = {"id": "1934.007.001%2F1934_007_001-v0002.tif"}
 
-    print(run(event, {}))
+    run(event, {})

--- a/manifest_lambda/handler.py
+++ b/manifest_lambda/handler.py
@@ -6,7 +6,7 @@ from iiifManifest import iiifManifest
 from MetadataMappings import MetadataMappings
 import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
-from graphql import query_appsync, build_manifest_query, build_file_query
+from graphql import query_appsync, build_manifest_query, build_image_query
 import json
 
 
@@ -29,15 +29,20 @@ def run(event, context):
         try:
             if resource == 'manifest':
                 standard_json = query_appsync(graphql_url, graphql_key, build_manifest_query(id)).get('data', {}).get('getItem')
+                if standard_json.get('id') is None:
+                    standard_json = {}
                 manifest_json = get_manifest(id, standard_json, iiif_base_url)
             elif resource in ('canvas', 'annotation_page', 'annotation'):  # This assumes the canvas is named with the full file id, including extension
-                standard_json = query_appsync(graphql_url, graphql_key, build_file_query(id)).get('data', {}).get('getFile')
+                standard_json = query_appsync(graphql_url, graphql_key, build_image_query(id)).get('data', {}).get('getImage')
+                if standard_json.get('id') is None:
+                    standard_json = {}
                 manifest_json = get_manifest(id, standard_json, iiif_base_url)
                 if resource in ('annotation_page', 'annotation'):  # This assumes one annotation_page per canvas
                     manifest_json = manifest_json.get('items')[0]
                     if resource in ('annotation'):  # This assumes one annotation per annoation_page
                         manifest_json = manifest_json.get('items')[0]
         except Exception as err:
+            sentry_sdk.capture_exception(err)
             print("error on {}".format(id))
             print("Error: {}".format(err))
             manifest_json = {}
@@ -46,8 +51,8 @@ def run(event, context):
         print("resource =", resource)
         print("id =", id)
 
-    with open('manifest.json', 'w') as output_file:
-        json.dump(manifest_json, output_file, indent=2)
+    # with open('manifest.json', 'w') as output_file:
+    #     json.dump(manifest_json, output_file, indent=2)
 
     return build_http_results(manifest_json)
 
@@ -119,8 +124,6 @@ def _get_ssm_parameter(name: str) -> str:
 # python -c 'from handler import *; test()'
 
 def test():
-    # import pprint
-    # pp = pprint.PrettyPrinter(indent=4)
     event = {}
     event['resource'] = '/manifest/{id}'
     event['pathParameters'] = {"id": "BPP1001_EAD"}
@@ -129,6 +132,8 @@ def test():
     # event['id'] = 'aspace_8177830828c061f66a16bb593fa13af1'
     # event['pathParameters']['id'] = 'pv63fx74g23'
     event['pathParameters']['id'] = 'aspace_8177830828c061f66a16bb593fa13af1'
+    event['pathParameters']['id'] = '005065260'
+    # event['pathParameters']['id'] = '1934.007.001'
 
     # event['resource'] = '/canvas/{id}'
     # event['resource'] = '/annotation_page/{id}'

--- a/manifest_lambda/iiifImage.py
+++ b/manifest_lambda/iiifImage.py
@@ -25,7 +25,7 @@ class iiifImage():
             return False
         if self.standard_json.get('defaultFilePath', '').endswith('.pdf'):
             return False
-        if self.standard_json.get('defaultFile', {}).get('id', '').endswith('.pdf'):
+        if self.standard_json.get('defaultImage', {}).get('id', '').endswith('.pdf'):
             return False
         return True
 

--- a/manifest_lambda/iiifManifest.py
+++ b/manifest_lambda/iiifManifest.py
@@ -42,8 +42,8 @@ class iiifManifest():
         return ret
 
     def thumbnail(self):
-        if self.standard_json.get('defaultFile', False):
-            return [iiifImage(self.standard_json.get('defaultFile'), self.iiif_base_url).thumbnail()]
+        if self.standard_json.get('defaultImage', False):
+            return [iiifImage(self.standard_json.get('defaultImage'), self.iiif_base_url).thumbnail()]
         if self.type == 'Canvas':
             return [iiifImage(self.standard_json, self.iiif_base_url).thumbnail()]
         file_json = _search_for_default_image(self.standard_json)
@@ -162,7 +162,7 @@ class iiifManifest():
             pdfs = []
             for item_data in self.standard_json.get("children", {}).get("items", []):
                 if _item_has_pdf(item_data):
-                    fileUrl = re.sub(r"^(s3:\/\/[a-zA-z_-]*?\/)", "https://rbsc.library.nd.edu/", item_data.get("filePath"))
+                    fileUrl = re.sub(r"^(s3:\/\/[a-zA-z_-]*?\/)", "https://rbsc.library.nd.edu/", item_data.get("filePath"), '')
                     pdfs.append({
                         "id": fileUrl,
                         "type": "Text",

--- a/manifest_lambda/iiifManifest.py
+++ b/manifest_lambda/iiifManifest.py
@@ -1,6 +1,9 @@
 import os
 import re
 from iiifImage import iiifImage
+from get_iiif_manifest_provider import return_provider
+from get_iiif_manifest_pdf_rendering_section import return_pdf_rendering
+from iiifMedia import is_media, media_canvas
 
 
 class iiifManifest():
@@ -62,13 +65,16 @@ class iiifManifest():
             self.manifest_hash['viewingDirection'] = 'left-to-right'
         if self.thumbnail():
             self.manifest_hash['thumbnail'] = self.thumbnail()
+        pdf_rendering = return_pdf_rendering(self.standard_json)
+        if pdf_rendering:
+            self.manifest_hash["rendering"] = pdf_rendering
         if self._items():
             self.manifest_hash['items'] = self._items()
         part_of = _return_part_of(self.type, self.standard_json.get('parentId'), self.standard_json.get('parent', {}).get('level'), self.iiif_base_url)
         if part_of:
             self.manifest_hash["partOf"] = [part_of]
         self.add_context()
-        provider = _return_provider(self.standard_json.get('repository'), self.standard_json.get('level', 'file'))
+        provider = return_provider(self.standard_json.get('repository'), self.standard_json.get('level', 'file'))
         if provider:
             self.manifest_hash['provider'] = [provider]
         required_statement = _return_required_statement(self.lang, self.standard_json.get('copyrightStatus'))
@@ -95,20 +101,28 @@ class iiifManifest():
     def _items(self):
         ret = []
         if self.type == 'Canvas':
-            image = iiifImage(self.standard_json, self.iiif_base_url)
-            ret.append({
-                'id': _annotation_page_id(self.iiif_base_url, self.standard_json.get('id')),
-                'type': 'AnnotationPage',
-                'items': [
-                    image.annotation(self._manifest_id(self.standard_json.get('id')))
-                ]
-            })
+            if is_media(self.standard_json):
+                media_canvas_results = media_canvas(self.iiif_base_url, self.standard_json)
+                if media_canvas_results:
+                    ret.append(media_canvas_results)
+            else:
+                image = iiifImage(self.standard_json, self.iiif_base_url)
+                ret.append({
+                    'id': _annotation_page_id(self.iiif_base_url, self.standard_json.get('id')),
+                    'type': 'AnnotationPage',
+                    'items': [
+                        image.annotation(self._manifest_id(self.standard_json.get('id')))
+                    ]
+                })
         else:
             for item_data in self.standard_json.get("children", {}).get("items", []):
                 if not _item_has_pdf(item_data):
                     ret.append(iiifManifest(self.iiif_base_url, item_data, self.mapping_template).manifest())
             if self.type != "Collection":  # A collection must only contain manifests as items
-                for file_data in self.standard_json.get("files", {}).get("items", []):
+                for file_data in self.standard_json.get("images", {}).get("items", []):
+                    if not _item_has_pdf(file_data):
+                        ret.append(iiifManifest(self.iiif_base_url, file_data, self.mapping_template).manifest())
+                for file_data in self.standard_json.get("media", {}).get("items", []):
                     if not _item_has_pdf(file_data):
                         ret.append(iiifManifest(self.iiif_base_url, file_data, self.mapping_template).manifest())
 
@@ -195,23 +209,6 @@ def _return_part_of(manifest_type: str, parent_id: str, parent_level: str, iiif_
     return part_of
 
 
-def _return_provider(repository: str, level: str) -> dict:
-    if not repository or not level or level == 'file':
-        return
-    repository = repository.lower()
-    if (repository == 'museum'):
-        return _snite_proivider()
-    elif (repository == 'unda'):
-        return _archives_proivider()
-    elif (repository == 'rare' or repository == 'curate'):
-        return _rbsc_proivider()
-    elif (repository == 'hesb'):
-        return _hesb_proivider()
-    else:
-        raise Exception("bad provider " + repository.lower())
-        return
-
-
 def _convert_label_value(lang: str, label: str, value) -> dict:
     if (label and value):
         return {
@@ -229,112 +226,12 @@ def _lang_wrapper(lang: str, line) -> dict:
     return {lang: line}
 
 
-def _snite_proivider() -> dict:
-    return {
-        "id": "https://sniteartmuseum.nd.edu/about-us/contact-us/",
-        "type": "Agent",
-        "label": {"en": ["Snite Museum of Art"]},
-        "homepage": [
-            {
-                "id": "https://sniteartmuseum.nd.edu",
-                "type": "Text",
-                "label": {"en": ["Snite Museum of Art"]},
-                "format": "text/html"
-            }
-        ],
-        "logo": [
-            {
-                "id": "https://sniteartmuseum.nd.edu/stylesheets/images/snite_logo@2x.png",
-                "type": "Image",
-                "format": "image/png",
-                "height": 100,
-                "width": 120
-            }
-        ]
-    }
-
-
-def _rbsc_proivider() -> dict:
-    return {
-        "id": "https://rarebooks.library.nd.edu/using",
-        "type": "Agent",
-        "label": {"en": ["Rare Books and Special Collections, Hesburgh Libraries, University of Notre Dame"]},
-        "homepage": [
-            {
-                "id": "https://rarebooks.library.nd.edu/",
-                "type": "Text",
-                "label": {"en": ["Rare Books and Special Collections, Hesburgh Libraries, University of Notre Dame"]},
-                "format": "text/html"
-            }
-        ],
-        "logo": [
-            {
-                "id": "https://rarebooks.library.nd.edu/images/hesburgh_mark.png",
-                "type": "Image",
-                "format": "image/png",
-                "height": 100,
-                "width": 120
-            }
-        ]
-    }
-
-
-def _archives_proivider() -> dict:
-    return {
-        "id": "http://archives.nd.edu/about/",
-        "type": "Agent",
-        "label": {"en": ["University of Notre Dame Archives, Hesburgh Libraries, University of Notre Dame"]},
-        "homepage": [
-            {
-                "id": "http://archives.nd.edu/",
-                "type": "Text",
-                "label": {"en": ["University of Notre Dame Archives"]},
-                "format": "text/html"
-            }
-        ],
-        "logo": [
-            {
-                "id": "https://rarebooks.library.nd.edu/images/hesburgh_mark.png",
-                "type": "Image",
-                "format": "image/png",
-                "height": 100,
-                "width": 120
-            }
-        ]
-    }
-
-
-def _hesb_proivider() -> dict:
-    return {
-        "id": "https://library.nd.edu",
-        "type": "Agent",
-        "label": {"en": ["General Collection, Hesburgh Libraries"]},
-        "homepage": [
-            {
-                "id": "https://library.nd.edu/",
-                "type": "Text",
-                "label": {"en": ["General Collection, Hesburgh Libraries"]},
-                "format": "text/html"
-            }
-        ],
-        "logo": [
-            {
-                "id": "https://library.nd.edu/static/media/library.logo.43a05388.png",
-                "type": "Image",
-                "format": "image/png",
-                "height": 100,
-                "width": 120
-            }
-        ]
-    }
-
-
 def _annotation_page_id(iiif_base_url: str, item_id: str) -> str:
     return os.path.join(iiif_base_url, 'annotation_page', item_id.replace("/", "%2F"))
 
 
 def _search_for_default_image(standard_json) -> dict:
-    for file_json in standard_json.get('files', {}).get('items', []):
+    for file_json in standard_json.get('images', {}).get('items', []):
         return file_json
 
 

--- a/manifest_lambda/iiifMedia.py
+++ b/manifest_lambda/iiifMedia.py
@@ -1,0 +1,80 @@
+import os
+
+
+def is_media(media_json) -> bool:
+    if is_audio(media_json) or is_video(media_json):
+        return True
+    return False
+
+
+def is_audio(media_json: dict) -> bool:
+    if media_json.get('mimeType').startswith('audio/') and media_json.get('mediaServer', '') and media_json.get('mediaResourceId', ''):
+        return True
+    return False
+
+
+def is_video(media_json: dict) -> bool:
+    if media_json.get('mimeType').startswith('video/') and media_json.get('mediaServer', '') and media_json.get('mediaResourceId', ''):
+        return True
+    return False
+
+
+def media_canvas(iiif_base_url: str, media_json: dict) -> dict:
+    media_type = ""
+    if is_audio(media_json):
+        media_type = 'Sound'
+    elif is_video(media_json):
+        media_type = "Video"
+    if not media_type:
+        return {}
+    return {
+        'id': _canvas_id(iiif_base_url, media_json.get('id', '')),
+        'type': 'Canvas',
+        'items': [_annotation_page(iiif_base_url, media_json.get('id', ''))]
+    }
+
+
+def _annotation_page(iiif_base_url: str, media_json: dict, media_type: str) -> dict:
+    return {
+        'id': _annotation_page_id(iiif_base_url, media_json.get('id', '')),
+        'type': 'AnnotationPage',
+        'items': [_annotation(iiif_base_url, media_json)]
+    }
+
+
+def _annotation(iiif_base_url: str, media_json: dict, media_type: str) -> dict:
+    return {
+        'id': _annotation_id(iiif_base_url, media_json.get('id', '')),
+        'type': 'Annotation',
+        'motivation': 'painting',
+        'target': _annotation_page_id(iiif_base_url, media_json.get('id', '')),
+        'body': _media(media_json, media_type)
+    }
+
+
+def _media(media_json: dict, media_type: str) -> dict:
+    return {
+        'id': _media_url_id(media_json),
+        'type': media_type,
+        'format': media_json.get('mimeType', 'audio/mp4')
+    }
+
+
+def _media_url_id(media_json: dict) -> str:
+    return os.path.join(media_json.get('mediaServer', ''), media_json.get('mediaResourceId', ''))
+
+
+def _annotation_id(iiif_base_url: str, media_id: str):
+    return _build_id(iiif_base_url, 'annotation', media_id)
+
+
+def _annotation_page_id(iiif_base_url: str, media_id: str):
+    return _build_id(iiif_base_url, 'annotation_page', media_id)
+
+
+def _canvas_id(iiif_base_url: str, media_id: str):
+    return _build_id(iiif_base_url, 'canvas', media_id)
+
+
+def _build_id(iiif_base_url: str, id_type: str, media_id: str) -> str:
+    return os.path.join(iiif_base_url, id_type, media_id.replace("/", "%2F"))

--- a/manifest_lambda/iiifMedia.py
+++ b/manifest_lambda/iiifMedia.py
@@ -8,13 +8,13 @@ def is_media(media_json) -> bool:
 
 
 def is_audio(media_json: dict) -> bool:
-    if media_json.get('mimeType').startswith('audio/') and media_json.get('mediaServer', '') and media_json.get('mediaResourceId', ''):
+    if media_json.get('mimeType', '').startswith('audio/') and media_json.get('mediaServer', '') and media_json.get('mediaResourceId', ''):
         return True
     return False
 
 
 def is_video(media_json: dict) -> bool:
-    if media_json.get('mimeType').startswith('video/') and media_json.get('mediaServer', '') and media_json.get('mediaResourceId', ''):
+    if media_json.get('mimeType', '').startswith('video/') and media_json.get('mediaServer', '') and media_json.get('mediaResourceId', ''):
         return True
     return False
 
@@ -30,7 +30,7 @@ def media_canvas(iiif_base_url: str, media_json: dict) -> dict:
     return {
         'id': _canvas_id(iiif_base_url, media_json.get('id', '')),
         'type': 'Canvas',
-        'items': [_annotation_page(iiif_base_url, media_json.get('id', ''))]
+        'items': [_annotation_page(iiif_base_url, media_json, media_type)]
     }
 
 
@@ -38,7 +38,7 @@ def _annotation_page(iiif_base_url: str, media_json: dict, media_type: str) -> d
     return {
         'id': _annotation_page_id(iiif_base_url, media_json.get('id', '')),
         'type': 'AnnotationPage',
-        'items': [_annotation(iiif_base_url, media_json)]
+        'items': [_annotation(iiif_base_url, media_json, media_type)]
     }
 
 

--- a/manifest_lambda/tests/1934.007.001.standard.json
+++ b/manifest_lambda/tests/1934.007.001.standard.json
@@ -59,7 +59,7 @@
   "children": {
     "items": []
   },
-  "files": {
+  "images": {
     "items": [
       {
         "id": "1934.007.001/1934_007_001-v0003.tif",

--- a/manifest_lambda/tests/BPP1001_EAD.standard.json
+++ b/manifest_lambda/tests/BPP1001_EAD.standard.json
@@ -2045,7 +2045,7 @@
       }
     ]
   },
-  "files": {
+  "images": {
     "items": [
       {
         "id": "collections/ead_xml/images/BPP_1001/BPP_1001-001.tif",

--- a/manifest_lambda/tests/aspace_8177830828c061f66a16bb593fa13af1.actual.manifest.json
+++ b/manifest_lambda/tests/aspace_8177830828c061f66a16bb593fa13af1.actual.manifest.json
@@ -6,6 +6,7 @@
       "\"The Aquital of Robert Kelly\""
     ]
   },
+  "viewingDirection": "left-to-right",
   "thumbnail": [
     {
       "id": "https://image-iiif.library.nd.edu/iiif/2/collections%2Fead_xml%2Fimages%2FBPP_1001%2FBPP_1001-001-F2/full/250,/0/default.jpg",
@@ -67,7 +68,6 @@
           ]
         }
       ],
-      "viewingDirection": "left-to-right",
       "height": 2000,
       "width": 2000
     },
@@ -118,16 +118,16 @@
           ]
         }
       ],
-      "viewingDirection": "left-to-right",
       "height": 2000,
       "width": 2000
     }
   ],
-  "viewingDirection": "left-to-right",
-  "partOf": {
-    "id": "iiif-manifest.test.edu/manifest/BPP1001_EAD",
-    "type": "Collection"
-  },
+  "partOf": [
+    {
+      "id": "iiif-manifest.test.edu/manifest/BPP1001_EAD",
+      "type": "Collection"
+    }
+  ],
   "provider": [
     {
       "id": "https://rarebooks.library.nd.edu/using",

--- a/manifest_lambda/tests/aspace_8177830828c061f66a16bb593fa13af1.standard.json
+++ b/manifest_lambda/tests/aspace_8177830828c061f66a16bb593fa13af1.standard.json
@@ -15,7 +15,7 @@
   "children": {
     "items": []
   },
-  "files": {
+  "images": {
     "items": [
       {
         "id": "collections/ead_xml/images/BPP_1001/BPP_1001-001-F2.tif",

--- a/manifest_lambda/tests/unit/test_handler.py
+++ b/manifest_lambda/tests/unit/test_handler.py
@@ -48,11 +48,13 @@ class Test(unittest.TestCase):
     def test_manifest(self):
         current_path = str(Path(__file__).parent.absolute())
         for one_id in self.ids:
-            # print("id = ", one_id)
             standard_json_file_name = os.path.join(current_path, '..', one_id + '.standard.json')
             with open(standard_json_file_name, 'r') as input_source:
                 standard_json = json.load(input_source)
             manifest_json = get_manifest(one_id, standard_json, self.iiif_base_url)
+            # actual_manifest_json_file_name = os.path.join(current_path, '..', one_id + '.actual.manifest.json')
+            # with open(actual_manifest_json_file_name, 'w') as output_file:
+            #     json.dump(manifest_json, output_file, indent=2)
             manifest_json_file_name = os.path.join(current_path, '..', one_id + '.manifest.json')
             # with open(manifest_json_file_name, 'w') as output_file:
             #     json.dump(manifest_json, output_file, indent=2)

--- a/manifest_lambda/tests/unit/test_iiifManifest.py
+++ b/manifest_lambda/tests/unit/test_iiifManifest.py
@@ -3,10 +3,10 @@ import json
 import os
 from pathlib import Path
 from manifest_lambda.iiifManifest import iiifManifest, _metadata_keys_that_have_top_level_values, _search_for_default_image, _annotation_page_id, \
-    _hesb_proivider, _archives_proivider, _rbsc_proivider, _snite_proivider, _lang_wrapper, _convert_label_value, _return_provider, \
+    _lang_wrapper, _convert_label_value, \
     _return_part_of, _return_required_statement, _return_rights, _return_summary
 from manifest_lambda.MetadataMappings import MetadataMappings
-
+from manifest_lambda.get_iiif_manifest_provider import _hesb_proivider, _archives_proivider, _rbsc_proivider, _snite_proivider, return_provider
 
 current_path = str(Path(__file__).parent.absolute())
 
@@ -94,7 +94,7 @@ class Test(unittest.TestCase):
 
     def test_return_provider(self):
         """ test_return_provider """
-        results = _return_provider(self.standard_json.get('repository'), self.standard_json.get('level', 'file'))
+        results = return_provider(self.standard_json.get('repository'), self.standard_json.get('level', 'file'))
         actual_id = results.get('id')
         expected_id = 'https://sniteartmuseum.nd.edu/about-us/contact-us/'
         self.assertEqual(actual_id, expected_id)


### PR DESCRIPTION
* Added Images and Media to GraphQL query
* Changed from referencing "files" to referencing "images" and "media"
* Added get_iiif_manifest_pdf_rendering_section.py to create manifest code for rendering pdfs.
* Added iiifMedia.py to create Canvas, AnnotationPage, Annotation and media body for manifest dealing with media.
* removed defaultFile and files from graphQL query
* changed reference from defaultFile to defaultImage
* changed from using getFile resolver to getImage resolver