### PR TITLE
Include file name in label

### DIFF
--- a/manifest_lambda/handler.py
+++ b/manifest_lambda/handler.py
@@ -154,8 +154,8 @@ def test():
     # event['id'] = 'aspace_8177830828c061f66a16bb593fa13af1'
     # event['pathParameters']['id'] = 'pv63fx74g23'
     event['pathParameters']['id'] = 'aspace_8177830828c061f66a16bb593fa13af1'
-    event['pathParameters']['id'] = '005065260'
-    event['pathParameters']['id'] = '1934.007.001'
+    # event['pathParameters']['id'] = '005065260'
+    # event['pathParameters']['id'] = '1934.007.001'
 
     # event['resource'] = '/canvas/{id}'
     # event['resource'] = '/annotation_page/{id}'

--- a/manifest_lambda/iiifManifest.py
+++ b/manifest_lambda/iiifManifest.py
@@ -57,6 +57,10 @@ class iiifManifest():
         label_contents = self.standard_json.get('title')
         if not label_contents:  # file records do not have a title field
             label_contents = self.standard_json.get('id')
+            try:
+                label_contents = os.path.basename(label_contents)  # if the id is a filepath, extract just the filename
+            except Exception:
+                pass
         self.manifest_hash = {
             'type': self.type,
             'id': self._manifest_id(self.standard_json.get('id')),

--- a/manifest_lambda/tests/1934.007.001.manifest.json
+++ b/manifest_lambda/tests/1934.007.001.manifest.json
@@ -26,7 +26,7 @@
       "id": "iiif-manifest.test.edu/canvas/1934.007.001%2F1934_007_001-v0003.tif",
       "label": {
         "en": [
-          "1934.007.001/1934_007_001-v0003.tif"
+          "1934_007_001-v0003.tif"
         ]
       },
       "thumbnail": [
@@ -76,7 +76,7 @@
       "id": "iiif-manifest.test.edu/canvas/1934.007.001%2F1934_007_001-v0001.tif",
       "label": {
         "en": [
-          "1934.007.001/1934_007_001-v0001.tif"
+          "1934_007_001-v0001.tif"
         ]
       },
       "thumbnail": [
@@ -126,7 +126,7 @@
       "id": "iiif-manifest.test.edu/canvas/1934.007.001%2F1934_007_001-v0002.tif",
       "label": {
         "en": [
-          "1934.007.001/1934_007_001-v0002.tif"
+          "1934_007_001-v0002.tif"
         ]
       },
       "thumbnail": [

--- a/manifest_lambda/tests/aspace_8177830828c061f66a16bb593fa13af1.manifest.json
+++ b/manifest_lambda/tests/aspace_8177830828c061f66a16bb593fa13af1.manifest.json
@@ -26,7 +26,7 @@
       "id": "iiif-manifest.test.edu/canvas/collections%2Fead_xml%2Fimages%2FBPP_1001%2FBPP_1001-001-F2.tif",
       "label": {
         "en": [
-          "collections/ead_xml/images/BPP_1001/BPP_1001-001-F2.tif"
+          "BPP_1001-001-F2.tif"
         ]
       },
       "thumbnail": [
@@ -76,7 +76,7 @@
       "id": "iiif-manifest.test.edu/canvas/collections%2Fead_xml%2Fimages%2FBPP_1001%2FBPP_1001-001.tif",
       "label": {
         "en": [
-          "collections/ead_xml/images/BPP_1001/BPP_1001-001.tif"
+          "BPP_1001-001.tif"
         ]
       },
       "thumbnail": [


### PR DESCRIPTION
* return just the filename as the label, instead of the complete file path.